### PR TITLE
Update Dockerfile

### DIFF
--- a/my-nginx-container/Dockerfile
+++ b/my-nginx-container/Dockerfile
@@ -9,5 +9,4 @@ COPY nginx.conf /etc/nginx/nginx.conf
 
 # Copy the website files to the container
 COPY site1 /usr/share/nginx/html/site1
-COPY site2 /usr/share/nginx/html/site2
 


### PR DESCRIPTION
The git diff shows that in the Dockerfile for the my-nginx-container, the line copying site2 to /usr/share/nginx/html/site2 has been removed.